### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,9 @@
 onedrive (2.4.0-2) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit (from
+    ./configure), Name (from ./configure), Repository, Repository-
+    Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 04 May 2020 23:00:23 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+onedrive (2.4.0-2) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Mon, 04 May 2020 23:00:23 +0000
+
 onedrive (2.4.0-1) unstable; urgency=medium
 
   * new upstream release

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: onedrive
 Section: net
 Priority: optional
 Maintainer: Norbert Preining <norbert@preining.info>
-Build-Depends: libcurl4-openssl-dev, libsqlite3-dev, ldc, 
+Build-Depends: libcurl4-openssl-dev, libsqlite3-dev, ldc,
   debhelper-compat (= 12), chrpath,
   pkg-config, libnotify-dev, bash-completion, systemd
 Standards-Version: 4.2.1
@@ -17,5 +17,5 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, init-system-helpers (>= 1.51)
 Description: folder synchronization with OneDrive
  OneDrive is the cloud storage system of Microsoft. This package provides
- the command line client specialising in synchronizing with OneDrive cloud 
+ the command line client specialising in synchronizing with OneDrive cloud
  storage.

--- a/debian/rules
+++ b/debian/rules
@@ -15,4 +15,3 @@ override_dh_auto_build:
 
 override_dh_installinit:
 	dh_installinit --no-start --no-enable
-

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+Name: onedrive
+Bug-Database: https://github.com/abraunegg/onedrive/issues
+Bug-Submit: https://github.com/abraunegg/onedrive
+Repository: https://github.com/abraunegg/onedrive.git
+Repository-Browse: https://github.com/abraunegg/onedrive


### PR DESCRIPTION
Fix some issues reported by lintian
* Trim trailing whitespace. ([file-contains-trailing-whitespace](https://lintian.debian.org/tags/file-contains-trailing-whitespace.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit (from ./configure), Name (from ./configure), Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/onedrive/dc8f1063-2305-4d62-b964-b05af7bb7e84.


## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/97/9c3c0916183c7a46238d7ab47432b6ee47de66.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/c0/3e17bfdb777894745e33adae7ecb88ed8ef21c.debug

No differences were encountered between the control files of package \*\*onedrive\*\*
### Control files of package onedrive-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-c03e17bfdb777894745e33adae7ecb88ed8ef21c-] {+979c3c0916183c7a46238d7ab47432b6ee47de66+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/dc8f1063-2305-4d62-b964-b05af7bb7e84/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/dc8f1063-2305-4d62-b964-b05af7bb7e84/diffoscope)).
